### PR TITLE
Add missing copy for default instance props to Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN  apk add --no-cache supervisor
 COPY ./files/SMPPSim.sh /opt/bin/SMPPSim.sh
 COPY ./files/main.sh /opt/bin/main.sh
 COPY ./files/smppsim.jar /opt/SMPPSim/
+COPY ./conf/smppsim.props /opt/SMPPSim/conf/SMPPSim.props
 
 VOLUME /conf
 VOLUME /libs


### PR DESCRIPTION
We weren't copying the default instance props inside the container. Changed the dockerfile to add them and create the container without any external dependencies.