### PR TITLE
Set SMPPSim's message-id to current timestamp

### DIFF
--- a/files/SMPPSim.sh
+++ b/files/SMPPSim.sh
@@ -24,6 +24,10 @@ function die ()
 
 [ -n "${1:-}" ] || die 1 "Missing settings file argument."
 
+# Reset message-id to avoid duplicates in db when restarting the service
+# See 26530
+sed -i -e "s|START_MESSAGE_ID_AT=.*|START_MESSAGE_ID_AT=$(date +%s)|" $1
+
 instance=$(basename $1 .props)
 _CONF=$1
 _LOG="/var/log/${instance}.log"


### PR DESCRIPTION
This commit resets the id that SMPPSim gives to the messages to be the current timestamp in Unix time instead of starting from 0. It resets the id for every instance of SMPPSim that is launched.